### PR TITLE
Add last crackme rss

### DIFF
--- a/static/img/rss.svg
+++ b/static/img/rss.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"> 
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="128px" height="128px" id="RSSicon" viewBox="0 0 256 256">
+<defs>
+<linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915" id="RSSg">
+<stop  offset="0.0" stop-color="#E3702D"/><stop  offset="0.1071" stop-color="#EA7D31"/>
+<stop  offset="0.3503" stop-color="#F69537"/><stop  offset="0.5" stop-color="#FB9E3A"/>
+<stop  offset="0.7016" stop-color="#EA7C31"/><stop  offset="0.8866" stop-color="#DE642B"/>
+<stop  offset="1.0" stop-color="#D95B29"/>
+</linearGradient>
+</defs>
+<rect width="256" height="256" rx="55" ry="55" x="0"  y="0"  fill="#CC5D15"/>
+<rect width="246" height="246" rx="50" ry="50" x="5"  y="5"  fill="#F49C52"/>
+<rect width="236" height="236" rx="47" ry="47" x="10" y="10" fill="url(#RSSg)"/>
+<circle cx="68" cy="189" r="24" fill="#FFF"/>
+<path d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z" fill="#FFF"/>
+<path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="#FFF"/>
+</svg>

--- a/template/crackme/lasts.tmpl
+++ b/template/crackme/lasts.tmpl
@@ -4,7 +4,7 @@
 
  <div class="container grid-lg wrapper">
         
-        <h2>Latest Crackmes</h2>
+        <h2>Latest Crackmes <a href="/rss/crackme"><img src="/static/img/rss.svg" width="16" height="16" /></a></h2>
         <table class="table table-striped">
             <thead>
                 <tr style="text-align: center;">

--- a/vendor/app/controller/rss.go
+++ b/vendor/app/controller/rss.go
@@ -44,10 +44,10 @@ func RssCrackmesGET(w http.ResponseWriter, r *http.Request) {
 			Title: v.Name+" ["+v.Platform+" - "+v.Lang+" - "+diffs[diffNum-1]+"]",
 			Description: v.Info,
 			Author: v.Author,
-			PubDate: v.CreatedAt.Format(time.RFC822),
+			PubDate: v.CreatedAt.Format(time.RFC1123Z),
 			Category: v.Platform,
 			Link: "https://crackmes.one/crackme/"+v.HexId,
-			Guid: v.HexId,
+			Guid: "https://crackmes.one/crackme/"+v.HexId,
 		})
 	}
 	crss := rss{

--- a/vendor/app/controller/rss.go
+++ b/vendor/app/controller/rss.go
@@ -1,0 +1,69 @@
+package controller
+
+import (
+	"app/model"
+	"encoding/xml"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type item struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	Description string `xml:"description"`
+	Author      string `xml:"author"`
+	Category    string `xml:"category"`
+	Guid        string `xml:"guid"`
+	PubDate     string `xml:"pubDate"`
+}
+
+type rss struct {
+	Version     string `xml:"version,attr"`
+	Title       string `xml:"channel>title"`
+	Description string `xml:"channel>description"`
+	Link        string `xml:"channel>link"`
+	Items       []item `xml:"channel>item"`
+}
+
+var diffs = []string{"Very Easy", "Easy", "Medium", "Hard", "Very Hard", "Insane"}
+
+func RssCrackmesGET(w http.ResponseWriter, r *http.Request) {
+	crackmes, err := model.LastCrackMes()
+	if err != nil {
+		log.Println(err)
+		Error500(w, r)
+		return
+	}
+
+	var items []item
+	for _, v := range(crackmes) {
+		diffNum, _ := strconv.Atoi(v.Difficulty)
+		items = append(items, item{
+			Title: v.Name+" ["+v.Platform+" - "+v.Lang+" - "+diffs[diffNum-1]+"]",
+			Description: v.Info,
+			Author: v.Author,
+			PubDate: v.CreatedAt.Format(time.RFC822),
+			Category: v.Platform,
+			Link: "https://crackmes.one/crackme/"+v.HexId,
+			Guid: v.HexId,
+		})
+	}
+	crss := rss{
+		Version: "2.0",
+		Title: "Latest crackmes - crackmes.one",
+		Link: "https://crackmes.one/lasts",
+		Description: "The latest 50 crackmes from crackmes.one",
+		Items: items,
+	}
+
+	b, err := xml.MarshalIndent(crss, "", "    ")
+	if err != nil {
+		log.Println(err)
+		Error500(w, r)
+		return
+	}
+
+	w.Write(b)
+}

--- a/vendor/app/controller/rss.go
+++ b/vendor/app/controller/rss.go
@@ -58,12 +58,14 @@ func RssCrackmesGET(w http.ResponseWriter, r *http.Request) {
 		Items: items,
 	}
 
-	b, err := xml.MarshalIndent(crss, "", "    ")
+	b, err := xml.Marshal(crss)
 	if err != nil {
 		log.Println(err)
 		Error500(w, r)
 		return
 	}
 
+	w.Header().Set("content-type", "application/rss+xml; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
 	w.Write(b)
 }

--- a/vendor/app/route/route.go
+++ b/vendor/app/route/route.go
@@ -136,6 +136,11 @@ func routes() *httprouter.Router {
 	r.GET("/debug/pprof/*pprof", hr.Handler(alice.
 		New(acl.DisallowAnon).
 		ThenFunc(pprofhandler.Handler)))
+
+	// RSS
+	r.GET("/rss/crackme", hr.Handler(alice.
+		New().
+		ThenFunc(controller.RssCrackmesGET)))
 	return r
 }
 


### PR DESCRIPTION
Add the latest crackmes listing as an rss feed to `/rss/crackme`.

There is no caching so every GET is a new db access. If it's required I could add something like that.

I don't know about code quality, if it's bad then with instructions I'll fix it.